### PR TITLE
Remove timestamp from message listings

### DIFF
--- a/src/__tests__/received-messages.test.tsx
+++ b/src/__tests__/received-messages.test.tsx
@@ -382,19 +382,6 @@ describe("ReceivedMessages", () => {
       );
     });
 
-    it("should display message accessories with formatted time", async () => {
-      const { container, getByTestId } = render(<ReceivedMessages />);
-
-      await waitFor(() => {
-        expect(mockGetReceivedMessages).toHaveBeenCalled();
-        expect(getByTestId("list")).toHaveAttribute("data-loading", "false");
-      });
-
-      const listItems = container.querySelectorAll('[data-testid="list-item"]');
-      const accessories = listItems[0].querySelector('[data-testid="item-accessories"]');
-      expect(accessories?.textContent).toContain("text");
-    });
-
     it("should handle loading error", async () => {
       const error = new Error("Failed to load messages");
       mockGetReceivedMessages.mockRejectedValue(error);

--- a/src/__tests__/sent-messages.test.tsx
+++ b/src/__tests__/sent-messages.test.tsx
@@ -407,19 +407,6 @@ describe("SentMessages", () => {
       );
     });
 
-    it("should display formatted timestamp as accessory", async () => {
-      render(<SentMessages />);
-
-      await waitFor(() => {
-        const accessories = screen.getAllByTestId("accessory");
-        expect(accessories.length).toBeGreaterThan(0);
-        // Check that timestamps are formatted (should contain : for time)
-        accessories.forEach((acc) => {
-          expect(acc.textContent).toMatch(/\d{1,2}:\d{2}/);
-        });
-      });
-    });
-
     it("should render message actions", async () => {
       render(<SentMessages />);
 

--- a/src/commands/received-messages/list.tsx
+++ b/src/commands/received-messages/list.tsx
@@ -100,16 +100,6 @@ export default function ReceivedMessages() {
             <List.Item
               key={message.id}
               title={message.preview}
-              accessories={[
-                {
-                  text: message.timestamp.toLocaleString([], {
-                    month: "short",
-                    day: "numeric",
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  }),
-                },
-              ]}
               actions={
                 <ActionPanel>
                   <Action.Push title="View Message" icon={Icon.Eye} target={<MessageDetail message={message} />} />

--- a/src/commands/sent-messages/list.tsx
+++ b/src/commands/sent-messages/list.tsx
@@ -100,16 +100,6 @@ export default function SentMessages() {
             <List.Item
               key={message.id}
               title={message.preview}
-              accessories={[
-                {
-                  text: message.timestamp.toLocaleString([], {
-                    month: "short",
-                    day: "numeric",
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  }),
-                },
-              ]}
               actions={
                 <ActionPanel>
                   <Action.Push title="View Message" icon={Icon.Eye} target={<MessageDetail message={message} />} />


### PR DESCRIPTION
- Remove timestamp accessories from sent messages list items
- Remove timestamp accessories from received messages list items
- Update tests to remove checks for timestamp accessories
- Datetime still available in metadata panel on detail view