### PR TITLE
refactor(chat): restructure chat command with inline model picker and full-text input

### DIFF
--- a/src/commands/chat/execute.tsx
+++ b/src/commands/chat/execute.tsx
@@ -1,128 +1,43 @@
-import { Action, ActionPanel, Icon, List, showToast, Toast } from "@raycast/api";
-import { useRef, useState } from "react";
-import { PasteAction } from "../../components/paste-action";
-import { executeConversation } from "../../utils/claude-cli";
+import { Action, ActionPanel, Form, Icon, useNavigation } from "@raycast/api";
+import { useState } from "react";
+import { MODELS } from "./models";
 
-const SYSTEM_PROMPT = "You are a helpful assistant. Respond directly and concisely.";
-const SNIPPET_LENGTH = 60;
-
-interface ChatMessage {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-}
-
-function snippet(text: string): string {
-  const oneLine = text.replace(/\s+/g, " ").trim();
-  return oneLine.length > SNIPPET_LENGTH ? `${oneLine.slice(0, SNIPPET_LENGTH)}…` : oneLine;
-}
-
-interface ChatConversationProps {
+interface ComposeFormProps {
+  initialText: string;
   model: string;
-  seedMessage?: string;
+  onModelChange: (model: string) => void;
+  onSubmit: (text: string) => void;
 }
 
-export default function ChatConversation({ model, seedMessage }: ChatConversationProps) {
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
-  const [searchText, setSearchText] = useState(seedMessage ?? "");
-  const [isLoading, setIsLoading] = useState(false);
-  const idCounter = useRef(0);
-
-  function makeId(): string {
-    idCounter.current += 1;
-    return String(idCounter.current);
-  }
-
-  async function send() {
-    const text = searchText.trim();
-    if (!text || isLoading) return;
-
-    const userMessage: ChatMessage = { id: makeId(), role: "user", content: text };
-    const nextMessages = [...messages, userMessage];
-    setMessages(nextMessages);
-    setSearchText("");
-    setIsLoading(true);
-
-    try {
-      const result = await executeConversation(
-        nextMessages.map((m) => ({ role: m.role, content: m.content })),
-        { model, systemPrompt: SYSTEM_PROMPT },
-      );
-      setMessages((prev) => [...prev, { id: makeId(), role: "assistant", content: result.result }]);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await showToast({ style: Toast.Style.Failure, title: "Chat failed", message: msg });
-      setMessages((prev) => [...prev, { id: makeId(), role: "assistant", content: `**Error:** ${msg}` }]);
-    } finally {
-      setIsLoading(false);
-    }
-  }
-
-  function newConversation() {
-    setMessages([]);
-    setSearchText("");
-  }
-
-  function messageActions(content?: string) {
-    return (
-      <ActionPanel>
-        <Action title="Send" icon={Icon.ArrowRight} onAction={send} />
-        {content && <Action.CopyToClipboard title="Copy Message" content={content} icon={Icon.Clipboard} />}
-        {content && <PasteAction content={content} />}
-        <Action
-          title="New Conversation"
-          icon={Icon.Plus}
-          shortcut={{ modifiers: ["cmd"], key: "n" }}
-          onAction={newConversation}
-        />
-      </ActionPanel>
-    );
-  }
-
-  // Newest at top: reverse the chronological list and prepend a "thinking" placeholder while awaiting a reply.
-  const ordered = [...messages].reverse();
+// Full-text composer (⌘T from the chat) — a multi-line TextArea with no length limit,
+// for messages too long or too multi-line for the inline search bar.
+export default function ComposeForm({ initialText, model, onModelChange, onSubmit }: ComposeFormProps) {
+  const { pop } = useNavigation();
+  const [text, setText] = useState(initialText);
 
   return (
-    <List
-      isLoading={isLoading}
-      searchText={searchText}
-      onSearchTextChange={setSearchText}
-      filtering={false}
-      searchBarPlaceholder="Message Claude…"
-      isShowingDetail={messages.length > 0 || isLoading}
-      navigationTitle={`Chat (${model})`}
+    <Form
+      navigationTitle="Full Text Input"
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm
+            title="Send"
+            icon={Icon.ArrowRight}
+            onSubmit={() => {
+              if (!text.trim()) return;
+              onSubmit(text);
+              pop();
+            }}
+          />
+        </ActionPanel>
+      }
     >
-      {messages.length === 0 && !isLoading ? (
-        <List.EmptyView
-          icon={Icon.Message}
-          title="Start chatting"
-          description="Type a message and press Enter"
-          actions={messageActions()}
-        />
-      ) : (
-        <>
-          {isLoading && (
-            <List.Item
-              key="thinking"
-              title="Claude"
-              subtitle="Thinking…"
-              icon={Icon.Stars}
-              detail={<List.Item.Detail markdown="_Claude is thinking…_" />}
-              actions={messageActions()}
-            />
-          )}
-          {ordered.map((m) => (
-            <List.Item
-              key={m.id}
-              title={m.role === "user" ? "You" : "Claude"}
-              subtitle={snippet(m.content)}
-              icon={m.role === "user" ? Icon.Person : Icon.Stars}
-              detail={<List.Item.Detail markdown={m.content} />}
-              actions={messageActions(m.content)}
-            />
-          ))}
-        </>
-      )}
-    </List>
+      <Form.TextArea id="message" title="Message" placeholder="Message Claude…" value={text} onChange={setText} />
+      <Form.Dropdown id="model" title="Model" value={model} onChange={onModelChange}>
+        {MODELS.map((m) => (
+          <Form.Dropdown.Item key={m.value} value={m.value} title={m.title} />
+        ))}
+      </Form.Dropdown>
+    </Form>
   );
 }

--- a/src/commands/chat/list.tsx
+++ b/src/commands/chat/list.tsx
@@ -1,47 +1,144 @@
-import { Action, ActionPanel, Form, getSelectedText } from "@raycast/api";
-import { useEffect, useState } from "react";
-import ChatConversation from "./execute";
+import { Action, ActionPanel, Icon, List, showToast, Toast, useNavigation } from "@raycast/api";
+import { useRef, useState } from "react";
+import { PasteAction } from "../../components/paste-action";
+import { executeConversation } from "../../utils/claude-cli";
+import ComposeForm from "./execute";
+import { DEFAULT_MODEL, MODELS } from "./models";
 
-const MODELS = [
-  { value: "haiku", title: "Haiku (fast)" },
-  { value: "sonnet", title: "Sonnet (balanced)" },
-  { value: "opus", title: "Opus (powerful)" },
-];
+const SYSTEM_PROMPT = "You are a helpful assistant. Respond directly and concisely.";
+const SNIPPET_LENGTH = 60;
 
-const DEFAULT_MODEL = "sonnet";
+interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+}
 
-export default function ChatForm() {
-  const [seed, setSeed] = useState("");
+function snippet(text: string): string {
+  const oneLine = text.replace(/\s+/g, " ").trim();
+  return oneLine.length > SNIPPET_LENGTH ? `${oneLine.slice(0, SNIPPET_LENGTH)}…` : oneLine;
+}
+
+export default function ChatConversation() {
+  const { push } = useNavigation();
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [searchText, setSearchText] = useState("");
   const [model, setModel] = useState(DEFAULT_MODEL);
-  const [started, setStarted] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const idCounter = useRef(0);
 
-  useEffect(() => {
-    getSelectedText()
-      .then((text) => {
-        if (text) setSeed(text);
-      })
-      .catch(() => {});
-  }, []);
-
-  if (started) {
-    return <ChatConversation model={model} seedMessage={seed} />;
+  function makeId(): string {
+    idCounter.current += 1;
+    return String(idCounter.current);
   }
 
+  async function send(rawText: string) {
+    const text = rawText.trim();
+    if (!text || isLoading) return;
+
+    const userMessage: ChatMessage = { id: makeId(), role: "user", content: text };
+    const nextMessages = [...messages, userMessage];
+    setMessages(nextMessages);
+    setSearchText("");
+    setIsLoading(true);
+
+    try {
+      const result = await executeConversation(
+        nextMessages.map((m) => ({ role: m.role, content: m.content })),
+        { model, systemPrompt: SYSTEM_PROMPT },
+      );
+      setMessages((prev) => [...prev, { id: makeId(), role: "assistant", content: result.result }]);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await showToast({ style: Toast.Style.Failure, title: "Chat failed", message: msg });
+      setMessages((prev) => [...prev, { id: makeId(), role: "assistant", content: `**Error:** ${msg}` }]);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  function openFullTextInput() {
+    push(<ComposeForm initialText={searchText} model={model} onModelChange={setModel} onSubmit={send} />);
+  }
+
+  function newConversation() {
+    setMessages([]);
+    setSearchText("");
+  }
+
+  function messageActions(content?: string) {
+    return (
+      <ActionPanel>
+        <Action title="Send" icon={Icon.ArrowRight} onAction={() => send(searchText)} />
+        <Action
+          title="Full Text Input"
+          icon={Icon.Text}
+          shortcut={{ modifiers: ["cmd"], key: "t" }}
+          onAction={openFullTextInput}
+        />
+        {content && <Action.CopyToClipboard title="Copy Message" content={content} icon={Icon.Clipboard} />}
+        {content && <PasteAction content={content} />}
+        <Action
+          title="New Conversation"
+          icon={Icon.Plus}
+          shortcut={{ modifiers: ["cmd"], key: "n" }}
+          onAction={newConversation}
+        />
+      </ActionPanel>
+    );
+  }
+
+  // Newest at top: reverse the chronological list and prepend a "thinking" placeholder while awaiting a reply.
+  const ordered = [...messages].reverse();
+
   return (
-    <Form
-      navigationTitle="New Chat"
-      actions={
-        <ActionPanel>
-          <Action.SubmitForm title="Start Chat" onSubmit={() => setStarted(true)} />
-        </ActionPanel>
+    <List
+      isLoading={isLoading}
+      searchText={searchText}
+      onSearchTextChange={setSearchText}
+      filtering={false}
+      searchBarPlaceholder={messages.length > 0 ? "Ask another question…" : "Message Claude…"}
+      isShowingDetail={messages.length > 0 || isLoading}
+      navigationTitle="Chat"
+      searchBarAccessory={
+        <List.Dropdown tooltip="Model" value={model} onChange={setModel}>
+          {MODELS.map((m) => (
+            <List.Dropdown.Item key={m.value} value={m.value} title={m.title} />
+          ))}
+        </List.Dropdown>
       }
     >
-      <Form.Dropdown id="model" title="Model" value={model} onChange={setModel}>
-        {MODELS.map((m) => (
-          <Form.Dropdown.Item key={m.value} value={m.value} title={m.title} />
-        ))}
-      </Form.Dropdown>
-      <Form.Description text="The model stays fixed for the whole conversation." />
-    </Form>
+      {messages.length === 0 && !isLoading ? (
+        <List.EmptyView
+          icon={Icon.Message}
+          title="Start chatting"
+          description="Type a message and press Enter · ⌘T for full text input"
+          actions={messageActions()}
+        />
+      ) : (
+        <>
+          {isLoading && (
+            <List.Item
+              key="thinking"
+              title="Claude"
+              subtitle="Thinking…"
+              icon={Icon.Stars}
+              detail={<List.Item.Detail markdown="_Claude is thinking…_" />}
+              actions={messageActions()}
+            />
+          )}
+          {ordered.map((m) => (
+            <List.Item
+              key={m.id}
+              title={m.role === "user" ? "You" : "Claude"}
+              subtitle={snippet(m.content)}
+              icon={m.role === "user" ? Icon.Person : Icon.Stars}
+              detail={<List.Item.Detail markdown={m.content} />}
+              actions={messageActions(m.content)}
+            />
+          ))}
+        </>
+      )}
+    </List>
   );
 }

--- a/src/commands/chat/models.ts
+++ b/src/commands/chat/models.ts
@@ -1,0 +1,7 @@
+export const MODELS = [
+  { value: "haiku", title: "Haiku (fast)" },
+  { value: "sonnet", title: "Sonnet (balanced)" },
+  { value: "opus", title: "Opus (powerful)" },
+];
+
+export const DEFAULT_MODEL = "sonnet";


### PR DESCRIPTION
## Summary

- Move conversation UI to `list.tsx` and `ComposeForm` (⌘T) to `execute.tsx`
- Extract shared `MODELS` and `DEFAULT_MODEL` constants into new `models.ts`
- Replace initial model-selector Form screen with search bar dropdown accessory
- Add full-text TextArea composer accessible via `⌘T` shortcut